### PR TITLE
Hæma_changes

### DIFF
--- a/input/fsh/CodeSystem-FISH-Variables.fsh
+++ b/input/fsh/CodeSystem-FISH-Variables.fsh
@@ -4,7 +4,7 @@ Description: "FISH variables; test"
 
 * ^status = #active
 * ^publisher = "RKKP"
-* ^date = "2022-07-13T00:00:00+02:00"
+* ^date = "2025-02-21T00:00:00+02:00"
 * ^contact[0].telecom[0].system = #url
 * ^contact[0].telecom[0].value = "https://www.rkkp.dk/"
 * ^content = #complete
@@ -22,4 +22,6 @@ Description: "FISH variables; test"
 * #tp53_deletion "TP53 deletion" "TP53 deletion"
 * #1q21 "1q21 amplifikation" "1q21 amplifikation"
 * #11q22 "11q22/ATM amplifikation" "11q22/ATM amplifikation"
+* #1q21gain "1q21 gain (3 spot)" "1q21 gain (3 spot)"                   // Tilføjet 21.02.2025 af RK
+* #1qdeletion "1p deletion" "1p deletion"                               // Tilføjet 21.02.2025 af RK
 //Anden IGH translokation = other

--- a/input/fsh/ValueSet-FISHResult_202502.fsh
+++ b/input/fsh/ValueSet-FISHResult_202502.fsh
@@ -1,0 +1,21 @@
+ValueSet: FISHResult202502
+Title: "Resultat af FISH 202502"
+Description: "Resultat af FISH 202502 - Fjernet udgået udfald og tilføjet nye"
+
+* ^status = #active
+* ^experimental = true
+* ^publisher = "RKKP"
+* ^date = "2025-02-21T00:00:00+02:00"
+
+* FISHVariables#igh_fgfr3 "t(4;14)/IGH-FGFR3"
+* FISHVariables#igh_ccnd1 "t(11;14)/IGH-CCND1"
+* FISHVariables#igh_mbf "t(14;16)/IGH-MBF"
+* FISHVariables#igh_mafb "t(14;20)/IGH-MAFB"
+* FISHVariables#tp53_deletion "TP53 deletion"
+* FISHVariables#1q21gain "1q21 gain (3 spot)"               // Tilføjet 21.02.2025 af RK
+* FISHVariables#1q21 "1q21 amplifikation (≥ 4 spot)"        // Rettet display 21.02.2025 af RK
+* FISHVariables#1qdeletion "1p deletion"                    // Tilføjet 21.02.2025 af RK
+* ResultTest#changes "Andre forandringer påvist"            // Tilføjet 21.02.2025 af RK
+* GenericValues#other "Anden IGH translokation"
+* GenericValues#none "Ingen forandringer påvist"
+

--- a/input/fsh/ValueSet-FISHSamples_202502.fsh
+++ b/input/fsh/ValueSet-FISHSamples_202502.fsh
@@ -1,0 +1,19 @@
+ValueSet: FISHSamples202502
+Title: "Anvendte FISH prober 202502"
+Description: "Anvendte FISH prober 202502 - Fjernet udgået udfald og tilføjet nye"
+
+* ^status = #active
+* ^experimental = true
+* ^publisher = "RKKP"
+* ^date = "2025-02-21T00:00:00+02:00"
+
+* FISHVariables#igh_fgfr3 "t(4;14)/IGH-FGFR3"
+* FISHVariables#igh_ccnd1 "t(11;14)/IGH-CCND1"
+* FISHVariables#igh_mbf "t(14;16)/IGH-MBF"
+* FISHVariables#igh_mafb "t(14;20)/IGH-MAFB"
+* FISHVariables#tp53_deletion "TP53 deletion"
+* FISHVariables#1q21gain "1q21 gain (3 spot)"               // Tilføjet 21.02.2025 af RK
+* FISHVariables#1q21 "1q21 amplifikation (≥ 4 spot)"        // Rettet display 21.02.2025 af RK 
+* FISHVariables#1qdeletion "1p deletion"                    // Tilføjet 21.02.2025 af RK
+* GenericValues#other "Anden IGH translokation"
+


### PR DESCRIPTION
Følgende valgmuligheder udgår:
- IgH split signal
- 13q deletion
- 11a22/ATM amplifikation

Følgende valgmulighed omdøbes:
- ”1q21 amplifikation” til ”1q21 amplifikation (≥ 4 spot)”

Følgende valgmuligheder tilføjes:
- 1q21 gain (3 spot)
- 1p deletion
- Andre forandringer påvist (KUN FOR ”Resultat af FISH o.l.”)
