### PR TITLE
Add SearchParameters for 'latest' in Questionnaire and PlanDefinition…

### DIFF
--- a/_downloadPublisher.sh
+++ b/_downloadPublisher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 publisher_jar=publisher.jar
 publisher=./input-cache/${publisher_jar}
-version=1.8.25 #https://github.com/HL7/fhir-ig-publisher/releases
+version=2.0.9 # https://github.com/HL7/fhir-ig-publisher/releases
 
 # If publisher.jar is not found in cache folder, download it
 if [ ! -f "$publisher" ]; then

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        FSH_SUSHI_VERSION: 3.16.0
+        FSH_SUSHI_VERSION: 3.16.3
     volumes:
       - ig-output:/src/output:rw
       - ig-cache:/src/input-cache:rw
@@ -20,7 +20,7 @@ services:
 
   ig-nginx:
     container_name: "site"
-    image: nginx:1.27.5-alpine
+    image: nginx:1.28.0-alpine
     restart: unless-stopped
     volumes:
       - ig-output:/usr/share/nginx/html:rw

--- a/input/fsh/SearchParameter-PlanDefinitionLatest.fsh
+++ b/input/fsh/SearchParameter-PlanDefinitionLatest.fsh
@@ -1,0 +1,12 @@
+Instance: PlanDefinitionLatest
+InstanceOf: SearchParameter
+Usage: #definition
+* url = "https://kip.rkkp.dk/fhir/SearchParameter/PlanDefinitionLatest"
+* name = "PlanDefinitionLatest"
+* status = #active
+* description = "Search PlanDefinition for 'latest' extension"
+* code = #latest
+* base = #PlanDefinition
+* type = #token
+* expression = "PlanDefinition.extension.where(url='latest').value"
+* comparator = #eq

--- a/input/fsh/SearchParameter-QuestionnaireLatest.fsh
+++ b/input/fsh/SearchParameter-QuestionnaireLatest.fsh
@@ -1,0 +1,12 @@
+Instance: QuestionnaireLatest
+InstanceOf: SearchParameter
+Usage: #definition
+* url = "https://kip.rkkp.dk/fhir/SearchParameter/QuestionnaireLatest"
+* name = "QuestionnaireLatest"
+* status = #active
+* description = "Search Questionnaire for 'latest' extension"
+* code = #latest
+* base = #Questionnaire
+* type = #token
+* expression = "Questionnaire.extension.where(url='latest').value"
+* comparator = #eq

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -8,7 +8,7 @@ name: KIP Infrastructure
 title: KIP Infrastructure
 description: "The Danish Sundhedsvæsenets Kvalitetsinstitut defines a set of FHIR CodeSystems and ValueSets used for data collection."
 status: active
-version: 2.11.6
+version: 2.12.0
 fhirVersion: 4.0.1
 copyrightYear: 2022+
 releaseLabel: ci-build


### PR DESCRIPTION
## New

- Update Sushi from 3.16.0 -> 3.16.3
- Update IG-publisher from 1.8.25 -> 2.0.9
- Add two new `SearchParameter`s to get the latest version of a `Questionniare` and a `PlanDefinition`
- Set release to 2.12.0