### PR TITLE
Chore/package updates

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -77,7 +77,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ env.WEB_REPO }},${{ env.REGISTRY_REPO }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ docker compose start ig-server
 docker build --no-cache
 ```
 
-The Docker setup uses SUSHI 3.18.0 and the FHIR IG Publisher. The `ig-server` container transpiles FSH and runs the IG Publisher; the `ig-nginx` container serves the output at `http://localhost:4000`.
+The Docker setup uses SUSHI 3.20.0 and the FHIR IG Publisher. The `ig-server` container transpiles FSH and runs the IG Publisher; the `ig-nginx` container serves the output at `http://localhost:4000`.
 
 **CI**: PRs to `main` run `check-transpile` (validates FSH transpilation). Tagged pushes trigger the full release pipeline.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
       args:
         # https://github.com/FHIR/sushi/releases
-        FSH_SUSHI_VERSION: 3.19.0
+        FSH_SUSHI_VERSION: 3.20.0
     volumes:
       - ./output:/src/output:rw
       - ./input-cache:/src/input-cache:rw


### PR DESCRIPTION
Run after #83 

* Update deprecated `app-id` to `client-id` as mention [in the notes] (https://github.com/actions/create-github-app-token/tree/bcd2ba49218906704ab6c1aa796996da409d3eb1/#inputs).
* Update Sushi to version 3.20