### PR TITLE
Warn when a changed FSH file has no ^date update

### DIFF
--- a/.github/actions/check-fsh-dates/action.yaml
+++ b/.github/actions/check-fsh-dates/action.yaml
@@ -2,8 +2,8 @@ name: Check FSH dates
 description: >
   Warns when a .fsh file changed in a pull request has not had its
   "* ^date = ..." metadata updated. Modified files should have the ^date line
-  touched by the PR diff; added files should be dated today. Advisory only:
-  findings are warning annotations and never fail the job.
+  touched by the PR diff; added files should not predate sushi-config.yaml.
+  Advisory only: findings are warning annotations and never fail the job.
 
 inputs:
   base-sha:
@@ -25,6 +25,11 @@ inputs:
     description: UTC offset written into the suggested ^date value, matching the IG convention.
     required: false
     default: "+02:00"
+  sushi-config:
+    description: >
+      Config whose last-changed date is the oldest date an added file may carry.
+    required: false
+    default: sushi-config.yaml
 
 runs:
   using: composite
@@ -37,4 +42,5 @@ runs:
         PATH_GLOB: ${{ inputs.path-glob }}
         TIMEZONE: ${{ inputs.timezone }}
         UTC_OFFSET: ${{ inputs.utc-offset }}
+        SUSHI_CONFIG: ${{ inputs.sushi-config }}
       run: bash "${{ github.action_path }}/check-fsh-dates.sh"

--- a/.github/actions/check-fsh-dates/action.yaml
+++ b/.github/actions/check-fsh-dates/action.yaml
@@ -1,8 +1,9 @@
 name: Check FSH dates
 description: >
-  Verifies that every .fsh file changed in a pull request has its
-  "* ^date = ..." metadata updated. Modified files must have the ^date line
-  touched by the PR diff; added files must be dated today.
+  Warns when a .fsh file changed in a pull request has not had its
+  "* ^date = ..." metadata updated. Modified files should have the ^date line
+  touched by the PR diff; added files should be dated today. Advisory only:
+  findings are warning annotations and never fail the job.
 
 inputs:
   base-sha:
@@ -28,7 +29,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Verify ^date is bumped on changed FSH files
+    - name: Warn if ^date was not bumped on changed FSH files
       shell: bash
       env:
         BASE_SHA: ${{ inputs.base-sha }}

--- a/.github/actions/check-fsh-dates/action.yaml
+++ b/.github/actions/check-fsh-dates/action.yaml
@@ -1,0 +1,39 @@
+name: Check FSH dates
+description: >
+  Verifies that every .fsh file changed in a pull request has its
+  "* ^date = ..." metadata updated. Modified files must have the ^date line
+  touched by the PR diff; added files must be dated today.
+
+inputs:
+  base-sha:
+    description: Commit SHA of the pull request base, used as the diff starting point.
+    required: true
+  head-ref:
+    description: Git revision holding the PR changes to check. Defaults to the checked out HEAD.
+    required: false
+    default: HEAD
+  path-glob:
+    description: Git pathspec limiting which files are checked.
+    required: false
+    default: "*.fsh"
+  timezone:
+    description: Timezone used to resolve "today".
+    required: false
+    default: Europe/Copenhagen
+  utc-offset:
+    description: UTC offset written into the suggested ^date value, matching the IG convention.
+    required: false
+    default: "+02:00"
+
+runs:
+  using: composite
+  steps:
+    - name: Verify ^date is bumped on changed FSH files
+      shell: bash
+      env:
+        BASE_SHA: ${{ inputs.base-sha }}
+        HEAD_REF: ${{ inputs.head-ref }}
+        PATH_GLOB: ${{ inputs.path-glob }}
+        TIMEZONE: ${{ inputs.timezone }}
+        UTC_OFFSET: ${{ inputs.utc-offset }}
+      run: bash "${{ github.action_path }}/check-fsh-dates.sh"

--- a/.github/actions/check-fsh-dates/check-fsh-dates.sh
+++ b/.github/actions/check-fsh-dates/check-fsh-dates.sh
@@ -5,7 +5,8 @@
 #
 #   - modified/renamed file -> the ^date line must appear on the added side of
 #     the PR diff, so any deliberately chosen value is respected
-#   - added file            -> its ^date must be today
+#   - added file            -> its ^date must not predate sushi-config.yaml,
+#     i.e. it must be the config's date, the PR's date, or newer
 #   - file without a ^date  -> skipped (e.g. Alias.fsh)
 #
 # Findings are emitted as GitHub warning annotations. The check is advisory:
@@ -17,6 +18,8 @@
 #   PATH_GLOB   git pathspec to limit the check           (default *.fsh)
 #   TIMEZONE    timezone used to resolve "today"          (default Europe/Copenhagen)
 #   UTC_OFFSET  offset used in the suggested ^date value  (default +02:00)
+#   SUSHI_CONFIG  config whose date is the floor for added files
+#                                                         (default sushi-config.yaml)
 
 set -euo pipefail
 
@@ -25,10 +28,25 @@ HEAD_REF="${HEAD_REF:-HEAD}"
 PATH_GLOB="${PATH_GLOB:-*.fsh}"
 TIMEZONE="${TIMEZONE:-Europe/Copenhagen}"
 UTC_OFFSET="${UTC_OFFSET:-+02:00}"
+SUSHI_CONFIG="${SUSHI_CONFIG:-sushi-config.yaml}"
 
 TODAY="$(TZ="$TIMEZONE" date +%F)"
 SUGGESTION="${TODAY}T00:00:00${UTC_OFFSET}"
 DIFF_RANGE="${BASE_SHA}...${HEAD_REF}"
+
+# An added file may not predate the IG configuration it ships with, so the
+# oldest acceptable date is the day sushi-config.yaml was last changed. When a
+# PR bumps the config itself that day is the PR's own date. Capped at today so
+# a config commit dated in the future cannot demand impossible dates, and
+# falling back to today when the config has no history to read.
+SUSHI_DATE="$(git log -1 --format=%cd --date=short "$HEAD_REF" -- "$SUSHI_CONFIG" 2>/dev/null || true)"
+if [ -n "$SUSHI_DATE" ] && [[ "$SUSHI_DATE" < "$TODAY" ]]; then
+  MIN_DATE="$SUSHI_DATE"
+else
+  MIN_DATE="$TODAY"
+fi
+
+echo "Added files must be dated ${MIN_DATE} or newer (${SUSHI_CONFIG}: ${SUSHI_DATE:-unknown}, today: ${TODAY})."
 
 warnings=0
 
@@ -57,14 +75,11 @@ while IFS=$'\t' read -r status path_a path_b; do
 
   if [ "$added" -eq 1 ]; then
     current="$(grep -m1 -oP '\^date\s*=\s*"\K[^"]+' "$file")"
-    case "$current" in
-      "$TODAY"*)
-        echo "OK ${file}: new file dated today"
-        ;;
-      *)
-        warn "$file" "New FSH file has ^date = \"${current}\" but must be dated today. Set: * ^date = \"${SUGGESTION}\""
-        ;;
-    esac
+    if [[ "${current:0:10}" < "$MIN_DATE" ]]; then
+      warn "$file" "New FSH file has ^date = \"${current}\" but must be dated ${MIN_DATE} or newer. Set: * ^date = \"${SUGGESTION}\""
+    else
+      echo "OK ${file}: new file dated ${current:0:10}"
+    fi
   else
     if git diff -U0 "$DIFF_RANGE" -- "${paths[@]}" | grep -qE '^\+[^+].*\^date'; then
       echo "OK ${file}: ^date updated in this PR"

--- a/.github/actions/check-fsh-dates/check-fsh-dates.sh
+++ b/.github/actions/check-fsh-dates/check-fsh-dates.sh
@@ -8,7 +8,8 @@
 #   - added file            -> its ^date must be today
 #   - file without a ^date  -> skipped (e.g. Alias.fsh)
 #
-# Findings are emitted as GitHub error annotations and the script exits 1.
+# Findings are emitted as GitHub warning annotations. The check is advisory:
+# it never fails, so a pull request is reported on but not blocked.
 #
 # Environment:
 #   BASE_SHA    commit the pull request branches off (required)
@@ -29,15 +30,15 @@ TODAY="$(TZ="$TIMEZONE" date +%F)"
 SUGGESTION="${TODAY}T00:00:00${UTC_OFFSET}"
 DIFF_RANGE="${BASE_SHA}...${HEAD_REF}"
 
-failed=0
+warnings=0
 
-report() {
+warn() {
   local file="$1" message="$2" line
   # grep -m1 rather than a "| head -1" pipe: under `set -o pipefail` the early
   # pipe close would kill grep with SIGPIPE and abort the whole check.
   line="$(grep -n -m1 '\^date' "$file" | cut -d: -f1 || true)"
-  echo "::error file=${file}${line:+,line=${line}}::${message}"
-  failed=1
+  echo "::warning file=${file}${line:+,line=${line}}::${message}"
+  warnings=$((warnings + 1))
 }
 
 while IFS=$'\t' read -r status path_a path_b; do
@@ -61,22 +62,22 @@ while IFS=$'\t' read -r status path_a path_b; do
         echo "OK ${file}: new file dated today"
         ;;
       *)
-        report "$file" "New FSH file has ^date = \"${current}\" but must be dated today. Set: * ^date = \"${SUGGESTION}\""
+        warn "$file" "New FSH file has ^date = \"${current}\" but must be dated today. Set: * ^date = \"${SUGGESTION}\""
         ;;
     esac
   else
     if git diff -U0 "$DIFF_RANGE" -- "${paths[@]}" | grep -qE '^\+[^+].*\^date'; then
       echo "OK ${file}: ^date updated in this PR"
     else
-      report "$file" "FSH file changed but ^date was not updated in this PR. Set: * ^date = \"${SUGGESTION}\""
+      warn "$file" "FSH file changed but ^date was not updated in this PR. Set: * ^date = \"${SUGGESTION}\""
     fi
   fi
 done < <(git diff --name-status --diff-filter=AMR "$DIFF_RANGE" -- "$PATH_GLOB")
 
-if [ "$failed" -ne 0 ]; then
-  echo ""
-  echo "One or more changed .fsh files are missing a ^date update. Today is ${TODAY} (${TIMEZONE})."
-  exit 1
+echo ""
+if [ "$warnings" -ne 0 ]; then
+  echo "${warnings} changed .fsh file(s) missing a ^date update. Today is ${TODAY} (${TIMEZONE})."
+  echo "This is a warning only, it does not block the pull request."
+else
+  echo "All changed .fsh files have an up-to-date ^date."
 fi
-
-echo "All changed .fsh files have an up-to-date ^date."

--- a/.github/actions/check-fsh-dates/check-fsh-dates.sh
+++ b/.github/actions/check-fsh-dates/check-fsh-dates.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Verifies that every .fsh file changed in a pull request has its
+# "* ^date = ..." metadata updated:
+#
+#   - modified/renamed file -> the ^date line must appear on the added side of
+#     the PR diff, so any deliberately chosen value is respected
+#   - added file            -> its ^date must be today
+#   - file without a ^date  -> skipped (e.g. Alias.fsh)
+#
+# Findings are emitted as GitHub error annotations and the script exits 1.
+#
+# Environment:
+#   BASE_SHA    commit the pull request branches off (required)
+#   HEAD_REF    revision holding the PR changes           (default HEAD)
+#   PATH_GLOB   git pathspec to limit the check           (default *.fsh)
+#   TIMEZONE    timezone used to resolve "today"          (default Europe/Copenhagen)
+#   UTC_OFFSET  offset used in the suggested ^date value  (default +02:00)
+
+set -euo pipefail
+
+BASE_SHA="${BASE_SHA:?BASE_SHA must be set}"
+HEAD_REF="${HEAD_REF:-HEAD}"
+PATH_GLOB="${PATH_GLOB:-*.fsh}"
+TIMEZONE="${TIMEZONE:-Europe/Copenhagen}"
+UTC_OFFSET="${UTC_OFFSET:-+02:00}"
+
+TODAY="$(TZ="$TIMEZONE" date +%F)"
+SUGGESTION="${TODAY}T00:00:00${UTC_OFFSET}"
+DIFF_RANGE="${BASE_SHA}...${HEAD_REF}"
+
+failed=0
+
+report() {
+  local file="$1" message="$2" line
+  # grep -m1 rather than a "| head -1" pipe: under `set -o pipefail` the early
+  # pipe close would kill grep with SIGPIPE and abort the whole check.
+  line="$(grep -n -m1 '\^date' "$file" | cut -d: -f1 || true)"
+  echo "::error file=${file}${line:+,line=${line}}::${message}"
+  failed=1
+}
+
+while IFS=$'\t' read -r status path_a path_b; do
+  case "$status" in
+    A*) file="$path_a"; added=1; paths=("$path_a") ;;
+    # For a rename both paths must be passed to git diff below, otherwise
+    # rename detection cannot fire and every line looks newly added.
+    R*) file="$path_b"; added=0; paths=("$path_a" "$path_b") ;;
+    *)  file="$path_a"; added=0; paths=("$path_a") ;;
+  esac
+
+  if ! grep -q '\^date' "$file"; then
+    echo "Skipping ${file}: no ^date field"
+    continue
+  fi
+
+  if [ "$added" -eq 1 ]; then
+    current="$(grep -m1 -oP '\^date\s*=\s*"\K[^"]+' "$file")"
+    case "$current" in
+      "$TODAY"*)
+        echo "OK ${file}: new file dated today"
+        ;;
+      *)
+        report "$file" "New FSH file has ^date = \"${current}\" but must be dated today. Set: * ^date = \"${SUGGESTION}\""
+        ;;
+    esac
+  else
+    if git diff -U0 "$DIFF_RANGE" -- "${paths[@]}" | grep -qE '^\+[^+].*\^date'; then
+      echo "OK ${file}: ^date updated in this PR"
+    else
+      report "$file" "FSH file changed but ^date was not updated in this PR. Set: * ^date = \"${SUGGESTION}\""
+    fi
+  fi
+done < <(git diff --name-status --diff-filter=AMR "$DIFF_RANGE" -- "$PATH_GLOB")
+
+if [ "$failed" -ne 0 ]; then
+  echo ""
+  echo "One or more changed .fsh files are missing a ^date update. Today is ${TODAY} (${TIMEZONE})."
+  exit 1
+fi
+
+echo "All changed .fsh files have an up-to-date ^date."

--- a/.github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh
+++ b/.github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh
@@ -4,7 +4,8 @@
 #
 # Each case builds a throwaway git repository, replays a pull request as a
 # base commit plus a head commit, runs the check against it and asserts the
-# exit code and the emitted annotations.
+# exit code and the emitted annotations. The check is advisory, so every case
+# expects exit code 0 and asserts on the warning annotations instead.
 #
 # Run locally:  bash .github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh
 
@@ -100,8 +101,8 @@ test_modified_without_date_bump() {
   BASE="$(git rev-parse HEAD)"
   fsh_file input/fsh/CodeSystem-A.fsh "$STALE" '* #b "B" "Second"'
   commit "edit without date bump"
-  expect "modified file without ^date bump fails" 1 \
-    "::error file=input/fsh/CodeSystem-A.fsh,line=6::" \
+  expect "modified file without ^date bump warns" 0 \
+    "::warning file=input/fsh/CodeSystem-A.fsh,line=6::" \
     "^date was not updated in this PR" \
     "${TODAY}T00:00:00+02:00"
 }
@@ -135,8 +136,8 @@ test_added_dated_stale() {
   BASE="$(git rev-parse HEAD)"
   fsh_file input/fsh/CodeSystem-New.fsh "$STALE"
   commit "add new file with a stale date"
-  expect "added file with stale date fails" 1 \
-    "::error file=input/fsh/CodeSystem-New.fsh,line=6::" \
+  expect "added file with stale date warns" 0 \
+    "::warning file=input/fsh/CodeSystem-New.fsh,line=6::" \
     "must be dated today"
 }
 
@@ -151,8 +152,8 @@ test_added_with_several_date_lines() {
     "* ^date = \"${STALE}T00:00:00+02:00\"
 * value[x] ^date = \"${STALE}T00:00:00+02:00\""
   commit "add a file carrying several ^date lines"
-  expect "file with several ^date lines is handled, not aborted" 1 \
-    "::error file=input/fsh/StructureDefinition-Multi.fsh,line=6::" \
+  expect "file with several ^date lines is handled, not aborted" 0 \
+    "::warning file=input/fsh/StructureDefinition-Multi.fsh,line=6::" \
     "must be dated today"
 }
 
@@ -176,8 +177,8 @@ test_renamed_without_date_bump() {
   git mv input/fsh/ValueSet-Old.fsh input/fsh/ValueSet-New.fsh
   printf '* #c "C" "Third"\n' >> input/fsh/ValueSet-New.fsh
   commit "rename without date bump"
-  expect "renamed file without ^date bump fails on the new path" 1 \
-    "::error file=input/fsh/ValueSet-New.fsh" \
+  expect "renamed file without ^date bump warns on the new path" 0 \
+    "::warning file=input/fsh/ValueSet-New.fsh" \
     "^date was not updated in this PR"
 }
 
@@ -202,8 +203,8 @@ test_pure_rename() {
   commit "rename only, content untouched"
   # A rename changes the resource's identity, so it is treated as a change
   # that needs a ^date bump.
-  expect "pure rename with no content change still requires a ^date bump" 1 \
-    "::error file=input/fsh/ValueSet-New.fsh" \
+  expect "pure rename with no content change still warns about the ^date" 0 \
+    "::warning file=input/fsh/ValueSet-New.fsh" \
     "^date was not updated in this PR"
 }
 
@@ -230,9 +231,10 @@ test_multiple_failures_reported() {
   fsh_file input/fsh/CodeSystem-A.fsh "$STALE" '* #b "B" "Second"'
   fsh_file input/fsh/CodeSystem-B.fsh "$STALE" '* #b "B" "Second"'
   commit "edit two files without date bumps"
-  expect "every offending file is annotated, not just the first" 1 \
-    "::error file=input/fsh/CodeSystem-A.fsh" \
-    "::error file=input/fsh/CodeSystem-B.fsh"
+  expect "every offending file is annotated, not just the first" 0 \
+    "::warning file=input/fsh/CodeSystem-A.fsh" \
+    "::warning file=input/fsh/CodeSystem-B.fsh" \
+    "2 changed .fsh file(s) missing a ^date update"
 }
 
 test_no_changes() {
@@ -265,6 +267,19 @@ test_ignores_base_branch_commits() {
     "OK input/fsh/CodeSystem-A.fsh: ^date updated in this PR"
 }
 
+test_findings_never_block() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE" '* #b "B" "Second"'
+  commit "edit without date bump"
+  # The check reports but must never fail the pull request.
+  expect "findings are advisory and never fail the check" 0 \
+    "1 changed .fsh file(s) missing a ^date update" \
+    "This is a warning only, it does not block the pull request."
+}
+
 # --- run ---------------------------------------------------------------------
 
 echo "Testing ${CHECK}"
@@ -285,6 +300,7 @@ test_deleted_and_non_fsh_ignored
 test_multiple_failures_reported
 test_no_changes
 test_ignores_base_branch_commits
+test_findings_never_block
 
 echo
 echo "${passed} passed, ${failed} failed"

--- a/.github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh
+++ b/.github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh
@@ -16,6 +16,11 @@ CHECK="${SCRIPT_DIR}/../check-fsh-dates.sh"
 TIMEZONE="Europe/Copenhagen"
 TODAY="$(TZ="$TIMEZONE" date +%F)"
 STALE="2020-01-01"
+# Relative so the cases keep meaning as time passes: the config sits in the
+# past, one date falls just before it and one between it and today.
+CONFIG_DATE="$(TZ="$TIMEZONE" date -d '90 days ago' +%F)"
+BEFORE_CONFIG="$(TZ="$TIMEZONE" date -d '91 days ago' +%F)"
+AFTER_CONFIG="$(TZ="$TIMEZONE" date -d '30 days ago' +%F)"
 
 passed=0
 failed=0
@@ -47,6 +52,16 @@ new_repo() {
 }
 
 commit() { git add -A; git commit -q -m "$1"; }
+
+# Commits with a fixed committer date, so the sushi-config.yaml date the check
+# reads is deterministic.
+commit_at() { # $1 = YYYY-MM-DD, $2 = message
+  git add -A
+  GIT_AUTHOR_DATE="${1}T12:00:00" GIT_COMMITTER_DATE="${1}T12:00:00" \
+    git commit -q -m "$2"
+}
+
+sushi_config() { printf 'id: dk.kip.rkkp.fhir.ig.core\nversion: %s\n' "$1" > sushi-config.yaml; }
 
 # Runs the check and asserts exit code, then that every remaining argument
 # appears in the output.
@@ -126,7 +141,7 @@ test_added_dated_today() {
   fsh_file input/fsh/CodeSystem-New.fsh "$TODAY"
   commit "add new file dated today"
   expect "added file dated today passes" 0 \
-    "OK input/fsh/CodeSystem-New.fsh: new file dated today"
+    "OK input/fsh/CodeSystem-New.fsh: new file dated ${TODAY}"
 }
 
 test_added_dated_stale() {
@@ -138,7 +153,7 @@ test_added_dated_stale() {
   commit "add new file with a stale date"
   expect "added file with stale date warns" 0 \
     "::warning file=input/fsh/CodeSystem-New.fsh,line=6::" \
-    "must be dated today"
+    "must be dated ${TODAY} or newer"
 }
 
 test_added_with_several_date_lines() {
@@ -154,7 +169,7 @@ test_added_with_several_date_lines() {
   commit "add a file carrying several ^date lines"
   expect "file with several ^date lines is handled, not aborted" 0 \
     "::warning file=input/fsh/StructureDefinition-Multi.fsh,line=6::" \
-    "must be dated today"
+    "must be dated ${TODAY} or newer"
 }
 
 test_file_without_date_field() {
@@ -280,6 +295,77 @@ test_findings_never_block() {
     "This is a warning only, it does not block the pull request."
 }
 
+
+test_added_dated_as_sushi_config() {
+  new_repo
+  sushi_config 1.0.0
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit_at "$CONFIG_DATE" "base with a config dated in the past"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-New.fsh "$CONFIG_DATE"
+  commit "add a file dated exactly as sushi-config.yaml"
+  expect "added file dated as sushi-config.yaml passes" 0 \
+    "Added files must be dated ${CONFIG_DATE} or newer" \
+    "OK input/fsh/CodeSystem-New.fsh: new file dated ${CONFIG_DATE}"
+}
+
+test_added_dated_after_sushi_config() {
+  new_repo
+  sushi_config 1.0.0
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit_at "$CONFIG_DATE" "base with a config dated in the past"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-New.fsh "$AFTER_CONFIG"
+  commit "add a file dated between the config and today"
+  # This is the case that used to warn: not today, but not older than the
+  # config either, so an ageing pull request is no longer nagged.
+  expect "added file newer than sushi-config.yaml but not today passes" 0 \
+    "OK input/fsh/CodeSystem-New.fsh: new file dated ${AFTER_CONFIG}"
+}
+
+test_added_dated_before_sushi_config() {
+  new_repo
+  sushi_config 1.0.0
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit_at "$CONFIG_DATE" "base with a config dated in the past"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-New.fsh "$BEFORE_CONFIG"
+  commit "add a file dated the day before the config"
+  expect "added file predating sushi-config.yaml by one day warns" 0 \
+    "::warning file=input/fsh/CodeSystem-New.fsh,line=6::" \
+    "must be dated ${CONFIG_DATE} or newer"
+}
+
+test_sushi_config_bumped_in_the_pr() {
+  new_repo
+  sushi_config 1.0.0
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit_at "$CONFIG_DATE" "base with a config dated in the past"
+  BASE="$(git rev-parse HEAD)"
+  sushi_config 1.1.0
+  fsh_file input/fsh/CodeSystem-New.fsh "$AFTER_CONFIG"
+  commit "bump the config and add a file dated before today"
+  # Bumping the config in the PR moves its date to the PR's own date, which
+  # raises the floor accordingly.
+  expect "bumping sushi-config.yaml in the PR raises the floor to the PR date" 0 \
+    "Added files must be dated ${TODAY} or newer" \
+    "::warning file=input/fsh/CodeSystem-New.fsh" \
+    "must be dated ${TODAY} or newer"
+}
+
+test_missing_sushi_config_falls_back_to_today() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit_at "$CONFIG_DATE" "base without any config"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-New.fsh "$AFTER_CONFIG"
+  commit "add a file dated before today"
+  expect "a missing sushi-config.yaml falls back to today" 0 \
+    "sushi-config.yaml: unknown" \
+    "Added files must be dated ${TODAY} or newer" \
+    "::warning file=input/fsh/CodeSystem-New.fsh"
+}
+
 # --- run ---------------------------------------------------------------------
 
 echo "Testing ${CHECK}"
@@ -291,6 +377,11 @@ test_modified_without_date_bump
 test_modified_to_deliberate_older_date
 test_added_dated_today
 test_added_dated_stale
+test_added_dated_as_sushi_config
+test_added_dated_after_sushi_config
+test_added_dated_before_sushi_config
+test_sushi_config_bumped_in_the_pr
+test_missing_sushi_config_falls_back_to_today
 test_added_with_several_date_lines
 test_file_without_date_field
 test_renamed_without_date_bump

--- a/.github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh
+++ b/.github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+#
+# Tests for check-fsh-dates.sh.
+#
+# Each case builds a throwaway git repository, replays a pull request as a
+# base commit plus a head commit, runs the check against it and asserts the
+# exit code and the emitted annotations.
+#
+# Run locally:  bash .github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="${SCRIPT_DIR}/../check-fsh-dates.sh"
+TIMEZONE="Europe/Copenhagen"
+TODAY="$(TZ="$TIMEZONE" date +%F)"
+STALE="2020-01-01"
+
+passed=0
+failed=0
+REPO=""
+
+# --- helpers -----------------------------------------------------------------
+
+fsh_file() { # $1 = path, $2 = date (YYYY-MM-DD), $3 = optional extra code
+  mkdir -p "$(dirname "$1")"
+  cat > "$1" <<EOF
+CodeSystem: Example
+Id: example
+Title: "Example"
+* ^status = #active
+* ^publisher = "RKKP"
+* ^date = "${2}T00:00:00+02:00"
+* #a "A" "First"
+${3:-}
+EOF
+}
+
+new_repo() {
+  REPO="$(mktemp -d)"
+  cd "$REPO" || exit 1
+  git init -q -b main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git config commit.gpgsign false
+}
+
+commit() { git add -A; git commit -q -m "$1"; }
+
+# Runs the check and asserts exit code, then that every remaining argument
+# appears in the output.
+expect() { # $1 = case name, $2 = expected exit code, rest = required substrings
+  local name="$1" want="$2"; shift 2
+  local out status=0 ok=1
+  out="$(BASE_SHA="$BASE" TIMEZONE="$TIMEZONE" bash "$CHECK" 2>&1)" || status=$?
+
+  if [ "$status" -ne "$want" ]; then
+    ok=0
+    echo "FAIL ${name}: expected exit ${want}, got ${status}"
+  fi
+  local needle
+  for needle in "$@"; do
+    if ! grep -qF -- "$needle" <<<"$out"; then
+      ok=0
+      echo "FAIL ${name}: output missing \"${needle}\""
+    fi
+  done
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS ${name}"
+    passed=$((passed + 1))
+  else
+    echo "----- output -----"
+    echo "$out"
+    echo "------------------"
+    failed=$((failed + 1))
+  fi
+
+  cd /
+  rm -rf "$REPO"
+}
+
+# --- cases -------------------------------------------------------------------
+
+test_modified_with_date_bump() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-A.fsh "$TODAY" '* #b "B" "Second"'
+  commit "edit with date bump"
+  expect "modified file with ^date bumped passes" 0 \
+    "OK input/fsh/CodeSystem-A.fsh: ^date updated in this PR"
+}
+
+test_modified_without_date_bump() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE" '* #b "B" "Second"'
+  commit "edit without date bump"
+  expect "modified file without ^date bump fails" 1 \
+    "::error file=input/fsh/CodeSystem-A.fsh,line=6::" \
+    "^date was not updated in this PR" \
+    "${TODAY}T00:00:00+02:00"
+}
+
+test_modified_to_deliberate_older_date() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "2019-05-05"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-A.fsh "2019-06-06" '* #b "B" "Second"'
+  commit "edit with a deliberately older date"
+  expect "touched ^date line is respected even if not today" 0 \
+    "OK input/fsh/CodeSystem-A.fsh: ^date updated in this PR"
+}
+
+test_added_dated_today() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-New.fsh "$TODAY"
+  commit "add new file dated today"
+  expect "added file dated today passes" 0 \
+    "OK input/fsh/CodeSystem-New.fsh: new file dated today"
+}
+
+test_added_dated_stale() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-New.fsh "$STALE"
+  commit "add new file with a stale date"
+  expect "added file with stale date fails" 1 \
+    "::error file=input/fsh/CodeSystem-New.fsh,line=6::" \
+    "must be dated today"
+}
+
+test_added_with_several_date_lines() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  # More than one ^date line must not abort the check: the first one is the
+  # resource date and the rest are reported against it.
+  fsh_file input/fsh/StructureDefinition-Multi.fsh "$STALE" \
+    "* ^date = \"${STALE}T00:00:00+02:00\"
+* value[x] ^date = \"${STALE}T00:00:00+02:00\""
+  commit "add a file carrying several ^date lines"
+  expect "file with several ^date lines is handled, not aborted" 1 \
+    "::error file=input/fsh/StructureDefinition-Multi.fsh,line=6::" \
+    "must be dated today"
+}
+
+test_file_without_date_field() {
+  new_repo
+  mkdir -p input/fsh
+  printf 'Alias: $sct = http://snomed.info/sct\n' > input/fsh/Alias.fsh
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  printf 'Alias: $sct = http://snomed.info/sct\nAlias: $loinc = http://loinc.org\n' > input/fsh/Alias.fsh
+  commit "edit alias file"
+  expect "file without a ^date field is skipped" 0 \
+    "Skipping input/fsh/Alias.fsh: no ^date field"
+}
+
+test_renamed_without_date_bump() {
+  new_repo
+  fsh_file input/fsh/ValueSet-Old.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  git mv input/fsh/ValueSet-Old.fsh input/fsh/ValueSet-New.fsh
+  printf '* #c "C" "Third"\n' >> input/fsh/ValueSet-New.fsh
+  commit "rename without date bump"
+  expect "renamed file without ^date bump fails on the new path" 1 \
+    "::error file=input/fsh/ValueSet-New.fsh" \
+    "^date was not updated in this PR"
+}
+
+test_renamed_with_date_bump() {
+  new_repo
+  fsh_file input/fsh/ValueSet-Old.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  git mv input/fsh/ValueSet-Old.fsh input/fsh/ValueSet-New.fsh
+  fsh_file input/fsh/ValueSet-New.fsh "$TODAY" '* #c "C" "Third"'
+  commit "rename with date bump"
+  expect "renamed file with ^date bump passes" 0 \
+    "OK input/fsh/ValueSet-New.fsh: ^date updated in this PR"
+}
+
+test_pure_rename() {
+  new_repo
+  fsh_file input/fsh/ValueSet-Old.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  git mv input/fsh/ValueSet-Old.fsh input/fsh/ValueSet-New.fsh
+  commit "rename only, content untouched"
+  # A rename changes the resource's identity, so it is treated as a change
+  # that needs a ^date bump.
+  expect "pure rename with no content change still requires a ^date bump" 1 \
+    "::error file=input/fsh/ValueSet-New.fsh" \
+    "^date was not updated in this PR"
+}
+
+test_deleted_and_non_fsh_ignored() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  fsh_file input/fsh/CodeSystem-B.fsh "$STALE"
+  printf 'version: 1.0.0\n' > sushi-config.yaml
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  git rm -q input/fsh/CodeSystem-B.fsh
+  printf 'version: 1.0.1\n' > sushi-config.yaml
+  commit "delete an fsh file and edit a non-fsh file"
+  expect "deleted files and non-fsh changes are ignored" 0 \
+    "All changed .fsh files have an up-to-date ^date."
+}
+
+test_multiple_failures_reported() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  fsh_file input/fsh/CodeSystem-B.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE" '* #b "B" "Second"'
+  fsh_file input/fsh/CodeSystem-B.fsh "$STALE" '* #b "B" "Second"'
+  commit "edit two files without date bumps"
+  expect "every offending file is annotated, not just the first" 1 \
+    "::error file=input/fsh/CodeSystem-A.fsh" \
+    "::error file=input/fsh/CodeSystem-B.fsh"
+}
+
+test_no_changes() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  printf 'notes\n' > README.md
+  commit "no fsh changes at all"
+  expect "pull request without fsh changes passes" 0 \
+    "All changed .fsh files have an up-to-date ^date."
+}
+
+test_ignores_base_branch_commits() {
+  new_repo
+  fsh_file input/fsh/CodeSystem-A.fsh "$STALE"
+  commit "base"
+  BASE="$(git rev-parse HEAD)"
+  git checkout -q -b feature
+  fsh_file input/fsh/CodeSystem-A.fsh "$TODAY" '* #b "B" "Second"'
+  commit "feature change with date bump"
+  # A commit landing on the base branch after the branch point must not be
+  # attributed to this pull request (three-dot diff semantics).
+  git checkout -q main
+  fsh_file input/fsh/CodeSystem-Other.fsh "$STALE"
+  commit "unrelated commit on main"
+  BASE="$(git rev-parse main)"
+  git checkout -q feature
+  expect "changes made on the base branch are not attributed to the PR" 0 \
+    "OK input/fsh/CodeSystem-A.fsh: ^date updated in this PR"
+}
+
+# --- run ---------------------------------------------------------------------
+
+echo "Testing ${CHECK}"
+echo "Today (${TIMEZONE}): ${TODAY}"
+echo
+
+test_modified_with_date_bump
+test_modified_without_date_bump
+test_modified_to_deliberate_older_date
+test_added_dated_today
+test_added_dated_stale
+test_added_with_several_date_lines
+test_file_without_date_field
+test_renamed_without_date_bump
+test_renamed_with_date_bump
+test_pure_rename
+test_deleted_and_non_fsh_ignored
+test_multiple_failures_reported
+test_no_changes
+test_ignores_base_branch_commits
+
+echo
+echo "${passed} passed, ${failed} failed"
+[ "$failed" -eq 0 ]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,27 @@ jobs:
       - name: IG transpile check
         uses: trifork/ig-publisher/.github/actions/ig-transpile@d2228e67ac377e81faca1da82d3e30253c387b8e # v2.2.11
 
+  # Check that every changed .fsh file has its "* ^date = ..." updated in the PR
+  check-fsh-dates:
+    name: Check FSH dates
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so the PR base commit is available for diffing, and
+          # check out the PR head itself so the working tree holds the authored files.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify ^date is bumped on changed FSH files
+        uses: ./.github/actions/check-fsh-dates
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+
   # Transpile and publish the IG, if it was pushed to main with a tag
   release:
     name: Transpile and publish to the IG release

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,8 @@ jobs:
       - name: IG transpile check
         uses: trifork/ig-publisher/.github/actions/ig-transpile@d2228e67ac377e81faca1da82d3e30253c387b8e # v2.2.11
 
-  # Check that every changed .fsh file has its "* ^date = ..." updated in the PR
+  # Warn when a changed .fsh file has not had its "* ^date = ..." updated in the
+  # PR. Advisory only, this job does not block the pull request.
   check-fsh-dates:
     name: Check FSH dates
     if: ${{ github.event_name == 'pull_request' }}
@@ -48,7 +49,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Verify ^date is bumped on changed FSH files
+      - name: Warn if ^date was not bumped on changed FSH files
         uses: ./.github/actions/check-fsh-dates
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,10 @@ env:
   WEB_REPO: kip-ig-website
   WEB_APP_LOCATION: "web/"
 
+# No GITHUB_TOKEN permissions by default, every job grants itself what it needs.
+# Publishing to the other repositories runs on the app token, not GITHUB_TOKEN.
+permissions: {}
+
 jobs:
   # Check if the IG transpiles without errors
   check-transpile:
@@ -24,6 +28,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     container: ghcr.io/trifork/ig-publisher:latest
+    permissions:
+      contents: read
 
     steps:
       # Checkout the repos needed
@@ -61,6 +67,8 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     container: ghcr.io/trifork/ig-publisher:latest
+    permissions:
+      contents: read
 
     steps:
       # Checkout the repos needed

--- a/.github/workflows/test-fsh-date-check.yaml
+++ b/.github/workflows/test-fsh-date-check.yaml
@@ -1,0 +1,87 @@
+name: Test FSH date check
+
+# Run locally with act:
+#   act workflow_dispatch -W .github/workflows/test-fsh-date-check.yaml \
+#     -P ubuntu-latest=node:24-bookworm
+
+on:
+  workflow_dispatch: # Enable manual run, and local runs via `act`
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/actions/check-fsh-dates/**'
+      - '.github/workflows/test-fsh-date-check.yaml'
+
+jobs:
+  # Exercise the check logic against purpose-built throwaway repositories
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run check-fsh-dates tests
+        run: bash .github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh
+
+  # Exercise the composite action itself against this repository's own files
+  integration:
+    name: Action wiring
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Commit an FSH change that forgets the ^date bump
+        id: fixture
+        run: |
+          set -euo pipefail
+          git config user.email "test@example.com"
+          git config user.name "Test"
+          echo "base=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+          # No "| head -1" pipe here: it would SIGPIPE git under pipefail
+          mapfile -t candidates < <(git ls-files 'input/fsh/CodeSystem-*.fsh')
+          file="${candidates[0]}"
+          echo "file=${file}" >> "$GITHUB_OUTPUT"
+          printf '* #zz-fixture "ZZ" "Fixture code"\n' >> "$file"
+          git commit -q -am "fixture: change an FSH file without bumping ^date"
+
+      - name: Action reports the missing ^date bump
+        id: stale
+        continue-on-error: true
+        uses: ./.github/actions/check-fsh-dates
+        with:
+          base-sha: ${{ steps.fixture.outputs.base }}
+
+      - name: Assert the action failed
+        env:
+          OUTCOME: ${{ steps.stale.outcome }}
+        run: |
+          set -euo pipefail
+          if [ "$OUTCOME" != "failure" ]; then
+            echo "Expected the action to fail on a missing ^date bump, got: ${OUTCOME}"
+            exit 1
+          fi
+          echo "Action correctly failed the stale change."
+
+      - name: Commit the ^date bump
+        env:
+          FILE: ${{ steps.fixture.outputs.file }}
+        run: |
+          set -euo pipefail
+          today="$(TZ=Europe/Copenhagen date +%F)"
+          sed -i -E "s|^\* \^date = \".*\"|* ^date = \"${today}T00:00:00+02:00\"|" "$FILE"
+          git diff --stat -- "$FILE"
+          git commit -q -am "fixture: bump ^date"
+
+      - name: Action accepts the bumped ^date
+        uses: ./.github/actions/check-fsh-dates
+        with:
+          base-sha: ${{ steps.fixture.outputs.base }}

--- a/.github/workflows/test-fsh-date-check.yaml
+++ b/.github/workflows/test-fsh-date-check.yaml
@@ -12,6 +12,9 @@ on:
       - '.github/actions/check-fsh-dates/**'
       - '.github/workflows/test-fsh-date-check.yaml'
 
+# No GITHUB_TOKEN permissions by default, every job grants itself what it needs
+permissions: {}
+
 jobs:
   # Exercise the check logic against purpose-built throwaway repositories
   unit:

--- a/.github/workflows/test-fsh-date-check.yaml
+++ b/.github/workflows/test-fsh-date-check.yaml
@@ -53,23 +53,29 @@ jobs:
           printf '* #zz-fixture "ZZ" "Fixture code"\n' >> "$file"
           git commit -q -am "fixture: change an FSH file without bumping ^date"
 
-      - name: Action reports the missing ^date bump
-        id: stale
-        continue-on-error: true
+      # The action is advisory, so this step is expected to succeed. It proves
+      # the wiring works and surfaces the annotation in the job log.
+      - name: Action annotates the missing ^date bump without failing
         uses: ./.github/actions/check-fsh-dates
         with:
           base-sha: ${{ steps.fixture.outputs.base }}
 
-      - name: Assert the action failed
+      # A passing step alone cannot tell an emitted warning from no output at
+      # all, so assert on what the check actually printed.
+      - name: Assert a warning was emitted and the check still passed
         env:
-          OUTCOME: ${{ steps.stale.outcome }}
+          BASE_SHA: ${{ steps.fixture.outputs.base }}
+          FILE: ${{ steps.fixture.outputs.file }}
         run: |
           set -euo pipefail
-          if [ "$OUTCOME" != "failure" ]; then
-            echo "Expected the action to fail on a missing ^date bump, got: ${OUTCOME}"
-            exit 1
-          fi
-          echo "Action correctly failed the stale change."
+          out="$(bash .github/actions/check-fsh-dates/check-fsh-dates.sh)"
+          echo "$out"
+
+          grep -qF "::warning file=${FILE}" <<<"$out" \
+            || { echo "Expected a warning annotation for ${FILE}"; exit 1; }
+          grep -qF "does not block the pull request" <<<"$out" \
+            || { echo "Expected the advisory notice in the summary"; exit 1; }
+          echo "Action warned about the stale change without failing."
 
       - name: Commit the ^date bump
         env:
@@ -85,3 +91,17 @@ jobs:
         uses: ./.github/actions/check-fsh-dates
         with:
           base-sha: ${{ steps.fixture.outputs.base }}
+
+      - name: Assert no warning remains
+        env:
+          BASE_SHA: ${{ steps.fixture.outputs.base }}
+        run: |
+          set -euo pipefail
+          out="$(bash .github/actions/check-fsh-dates/check-fsh-dates.sh)"
+          echo "$out"
+
+          if grep -qF '::warning' <<<"$out"; then
+            echo "Expected no warnings once the ^date was bumped"
+            exit 1
+          fi
+          grep -qF "All changed .fsh files have an up-to-date ^date." <<<"$out"


### PR DESCRIPTION
## What

Adds a `check-fsh-dates` job to the pull request pipeline. For every `.fsh` file touched by a PR it checks that the resource's `* ^date = ...` metadata reflects the PR:

| Change | Rule |
| --- | --- |
| Modified / renamed file | The `^date` line should be touched by the PR diff — a deliberately chosen value is respected, only an untouched date is flagged |
| Added file | Its `^date` should not predate `sushi-config.yaml`: the config's date, the PR's date, or newer |
| File with no `^date` (e.g. `Alias.fsh`) | Skipped |
| Deleted file, non-`.fsh` file | Ignored |

**The check is advisory.** Findings are GitHub *warning* annotations shown on the `^date` line of the diff, and the job always passes — a missing date update is never a merge blocker:

```
Added files must be dated 2026-07-29 or newer (sushi-config.yaml: 2026-07-29, today: 2026-08-03).
::warning file=input/fsh/ValueSet-Robot_DKR-2026-07.fsh,line=8::New FSH file has
^date = "2026-01-04T00:00:00+02:00" but must be dated 2026-07-29 or newer.
Set: * ^date = "2026-08-03T00:00:00+02:00"

1 changed .fsh file(s) missing a ^date update. Today is 2026-08-03 (Europe/Copenhagen).
This is a warning only, it does not block the pull request.
```

### Why added files are dated against the config

The "the `^date` line was touched" rule cannot apply to a new file, where every line is new. Requiring today's date instead meant a new file was warned about again every day the PR stayed open. The floor is now the day `sushi-config.yaml` was last changed, which gives a stable target for the lifetime of a PR. When a PR bumps the config — as the release process does — the floor becomes the PR's own date. It is capped at today so a config commit dated in the future cannot demand impossible dates, and falls back to today when the config has no history to read.

"Today" resolves in `Europe/Copenhagen`, and the suggested value uses `+02:00` to match the convention in `input/fsh` (1007 of 1008 files).

## How

The logic lives in a local composite action, `.github/actions/check-fsh-dates`, so the workflow stays readable and the script can be run standalone:

```bash
BASE_SHA=origin/main bash .github/actions/check-fsh-dates/check-fsh-dates.sh
```

Diffing uses `BASE_SHA...HEAD`, so commits landing on `main` after the branch point are not attributed to the PR. The job only needs `contents: read`, so it also works for pull requests from forks. Timezone, offset, pathspec and config path are inputs.

## Tests

`.github/actions/check-fsh-dates/tests/test-check-fsh-dates.sh` builds throwaway git repositories and replays pull requests through the check — 20 cases. Beyond the rules above they cover an added file dated exactly as the config, one day before it, and between it and today; a PR that bumps the config; a missing config; renames and pure renames; files with several `^date` lines; multiple findings in one PR; base-branch commits not being attributed to the PR; and a case pinning the advisory contract. Commits are dated with `GIT_COMMITTER_DATE` so the config date the check reads is deterministic, and the date fixtures are relative to today so the cases keep their meaning as time passes.

`.github/workflows/test-fsh-date-check.yaml` runs those tests and additionally exercises the composite action end to end: it commits an FSH change without a `^date` bump and asserts a warning is emitted while the step still passes, then bumps the date and asserts the warning is gone. Because a passing step cannot by itself be told apart from no output at all, those steps assert on what the check printed. Triggered manually or by PRs touching the action, and runs locally with:

```bash
act workflow_dispatch -W .github/workflows/test-fsh-date-check.yaml \
  -P ubuntu-latest=node:24-bookworm
```

Both jobs pass locally under `act` (20/20 unit tests, integration job green). Checked against `feature/RKKP-1441` as a real-world case: it adds three files dated 2026-07-31 and bumps the config the same day, and reports clean.

## Note for review

A pure rename with no content change still warns, on the grounds that the resource's identity changed. Currently documented by a test rather than settled.

If the warnings turn out to be ignored in practice, turning this into a hard gate is a two-line change: `::warning` → `::error` and a non-zero exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)